### PR TITLE
Fix .bashrc formatted in a bad way #38

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
+/pdtm
 dist/

--- a/pkg/path/unix.go
+++ b/pkg/path/unix.go
@@ -54,7 +54,7 @@ func add(path string) (bool, error) {
 			if err != nil {
 				return false, err
 			}
-			script := fmt.Sprintf("# Generated for pdtm. Do not edit.\n%s", script)
+			script := fmt.Sprintf("\n\n# Generated for pdtm. Do not edit.\n%s", script)
 			if _, err := f.Write([]byte(script)); err != nil {
 				return false, err
 			}


### PR DESCRIPTION
My .bashrc ends with a `}` and no newlines. The .bashrc modified by pdtm ended up looking like this:
```
. . .
  sed -e "s/^/$1/" "$2" > "$3"
}# Generated for pdtm. Do not edit.
export PATH=/home/edoardottt/.pdtm/go/bin:$PATH
```
which apparently is broken since 
```console
source ~/.bashrc
```
as stated in the related issue gives me `bash: /home/edoardottt/.bashrc: line 246: syntax error: unexpected end of file`.

Adding newlines before the comment inserted by the tool fixes the problem.

Honestly I don't know how to test this on other OSs, but I don't think it's a huge change two newlines..

This PR closes #38.