### PR TITLE
Add carriage return before pdtm section for rcFile

### DIFF
--- a/pkg/path/unix.go
+++ b/pkg/path/unix.go
@@ -54,7 +54,7 @@ func add(path string) (bool, error) {
 			if err != nil {
 				return false, err
 			}
-			script := fmt.Sprintf("# Generated for pdtm. Do not edit.\n%s", script)
+			script := fmt.Sprintf("\n# Generated for pdtm. Do not edit.\n%s", script)
 			if _, err := f.Write([]byte(script)); err != nil {
 				return false, err
 			}


### PR DESCRIPTION
Add fix for poorly formatted rcFile by ensuring a carriage return before the start of the pdtm section.

Fixes #38 