### PR TITLE
Output the currently installed versions

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -174,9 +174,9 @@ func installedVersion(i int, tool pkg.Tool) string {
 	if len(installedVersion) == 2 {
 		installedVersionString := strings.TrimPrefix(strings.TrimSpace(string(installedVersion[1])), "v")
 		if strings.Contains(tool.Version, installedVersionString) {
-			msg = au.Green("installed - latest").String()
+			msg = au.Green("installed - (" + tool.Version + ") latest").String()
 		} else {
-			msg = au.Yellow("installed - outdated").String()
+			msg = au.Yellow("installed - (" + tool.Version + ") outdated").String()
 		}
 	}
 	fmt.Printf("%d. %s (%s)\n", i, tool.Name, msg)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -161,9 +161,9 @@ func installedVersion(i int, tool pkg.Tool) string {
 		if errors.As(err, &notFoundError) {
 			osAvailable := isOsAvailable(tool)
 			if osAvailable {
-				msg = au.Red("not installed").String()
+				msg = au.BrightYellow("(not installed)").String()
 			} else {
-				msg = au.BrightRed("not supported").String()
+				msg = au.Gray(10, "(not supported)").String()
 			}
 		} else {
 			msg = "version not found"
@@ -174,12 +174,12 @@ func installedVersion(i int, tool pkg.Tool) string {
 	if len(installedVersion) == 2 {
 		installedVersionString := strings.TrimPrefix(strings.TrimSpace(string(installedVersion[1])), "v")
 		if strings.Contains(tool.Version, installedVersionString) {
-			msg = au.Green("installed - (" + tool.Version + ") latest").String()
+			msg = au.Green("(latest) (" + tool.Version + ")").String()
 		} else {
-			msg = au.Yellow("installed - (" + tool.Version + ") outdated").String()
+			msg = au.Red("(outdated) ("+installedVersionString+")").String() + " ➡ " + au.Green("("+tool.Version+")").String()
 		}
 	}
-	fmt.Printf("%d. %s (%s)\n", i, tool.Name, msg)
+	fmt.Printf("%d. %s %s\n", i, tool.Name, msg)
 	return msg
 }
 


### PR DESCRIPTION
Output the currently installed versions too in case the user wants to see the actual version.

Example:
```
> ./pdtm
...

1. subfinder (installed - (2.5.5) latest)
2. dnsx (installed - (1.1.1) latest)
3. naabu (installed - (2.1.1) latest)
4. httpx (installed - (1.2.6) latest)
5. nuclei (installed - (2.8.7) latest)
6. uncover (installed - (1.0.2) latest)
7. cloudlist (installed - (1.0.2) latest)
8. proxify (installed - (0.0.8) latest)
9. tlsx (installed - (1.0.4) latest)
10. notify (installed - (1.0.4) latest)
11. chaos-client (installed - (0.4.0) latest)
12. shuffledns (installed - (1.0.8) latest)
13. mapcidr (installed - (1.0.3) latest)
14. interactsh-server (not supported)
15. interactsh-client (installed - (1.0.7) latest)
16. katana (installed - (0.0.3) latest)

```

This PR closes #34.