### PR TITLE
Adding setup test

### DIFF
--- a/.github/workflows/setup-test.yaml
+++ b/.github/workflows/setup-test.yaml
@@ -31,8 +31,15 @@ jobs:
         run: go run . -ia
         working-directory: cmd/pdtm/
 
-      - name: Add binaries folder to ENV PATH
+      - name: Add binaries folder to ENV PATH (Unix-Like)
+        if: runner.os != 'Windows'
         run: go run . -show-path -nsp >> $GITHUB_PATH
+        working-directory: cmd/pdtm/
+
+      - name: Add binaries folder to ENV PATH (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          go run . -show-path -nsp | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         working-directory: cmd/pdtm/
 
       - name: Checking tools existence

--- a/.github/workflows/setup-test.yaml
+++ b/.github/workflows/setup-test.yaml
@@ -32,7 +32,6 @@ jobs:
         working-directory: cmd/pdtm/
 
       - name: Checking tools existence
-        # inverted match with grep
         run: |
           go run . | grep -vz "not installed"
         working-directory: cmd/pdtm/

--- a/.github/workflows/setup-test.yaml
+++ b/.github/workflows/setup-test.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/setup-test.yaml
+++ b/.github/workflows/setup-test.yaml
@@ -28,6 +28,12 @@ jobs:
         run: go run . -ia
         working-directory: cmd/pdtm/
 
+      - name: Checking tools existence
+        # inverted match with grep
+        run: |
+          go run . | grep -n "not installed"
+        working-directory: cmd/pdtm/
+
       - name: Update Run - Update All The Tools
         run: go run . -ua
         working-directory: cmd/pdtm/

--- a/.github/workflows/setup-test.yaml
+++ b/.github/workflows/setup-test.yaml
@@ -1,4 +1,4 @@
-name: 🔨 Build Test
+name: 🔨 Setup Test
 
 on:
   pull_request:

--- a/.github/workflows/setup-test.yaml
+++ b/.github/workflows/setup-test.yaml
@@ -31,3 +31,7 @@ jobs:
       - name: Update Run - Update All The Tools
         run: go run . -ua
         working-directory: cmd/pdtm/
+      
+      - name: Remove Run - Remove All The Tools
+        run: go run . -ra
+        working-directory: cmd/pdtm/

--- a/.github/workflows/setup-test.yaml
+++ b/.github/workflows/setup-test.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Checking tools existence
         # inverted match with grep
         run: |
-          go run . | grep -n "not installed"
+          go run . | grep -vz "not installed"
         working-directory: cmd/pdtm/
 
       - name: Update Run - Update All The Tools

--- a/.github/workflows/setup-test.yaml
+++ b/.github/workflows/setup-test.yaml
@@ -25,5 +25,9 @@ jobs:
         working-directory: cmd/pdtm/
 
       - name: Install Run - Setup All The Tools
-        run: go run .
+        run: go run . -ia
+        working-directory: cmd/pdtm/
+
+      - name: Update Run - Update All The Tools
+        run: go run . -ua
         working-directory: cmd/pdtm/

--- a/.github/workflows/setup-test.yaml
+++ b/.github/workflows/setup-test.yaml
@@ -1,0 +1,25 @@
+name: 🔨 Build Test
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Test Setups
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Install all the tools
+        run: go run .
+        working-directory: cmd/pdtm/

--- a/.github/workflows/setup-test.yaml
+++ b/.github/workflows/setup-test.yaml
@@ -31,6 +31,10 @@ jobs:
         run: go run . -ia
         working-directory: cmd/pdtm/
 
+      - name: Add binaries folder to ENV PATH
+        run: go run . -show-path -nsp >> $GITHUB_PATH
+        working-directory: cmd/pdtm/
+
       - name: Checking tools existence
         run: |
           go run . | grep -vz "not installed"

--- a/.github/workflows/setup-test.yaml
+++ b/.github/workflows/setup-test.yaml
@@ -20,6 +20,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
-      - name: Install all the tools
+      - name: Dry Run - No Tool Installed
+        run: go run .
+        working-directory: cmd/pdtm/
+
+      - name: Install Run - Setup All The Tools
         run: go run .
         working-directory: cmd/pdtm/

--- a/.github/workflows/setup-test.yaml
+++ b/.github/workflows/setup-test.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   build:
     name: Test Setups

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Flags:
 CONFIG:
    -config string            cli flag configuration file (default "$HOME/.config/pdtm/config.yaml")
    -bp, -binary-path string  custom location to download project binary (default "$HOME/.pdtm/go/bin")
-   -nsp, -no-set-path        don't add path to environment variables
+   -nsp, -no-set-path        disable adding path to environment variables
 
 INSTALL:
    -i, -install string[]  install single or multiple project by name (comma separated)
@@ -78,10 +78,10 @@ REMOVE:
    -ra, -remove-all      remove all the projects
 
 DEBUG:
-   -show-path      prints the current binaries path then exit
-   -version        show version of the project
-   -v              show verbose output
-   -nc, -no-color  disable output content coloring (ANSI escape codes)
+   -sp, -show-path  show the current binary path then exit
+   -version         show version of the project
+   -v, -verbose     show verbose output
+   -nc, -no-color   disable output content coloring (ANSI escape codes)
 ```
 
 ## Running pdtm

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Flags:
 CONFIG:
    -config string            cli flag configuration file (default "$HOME/.config/pdtm/config.yaml")
    -bp, -binary-path string  custom location to download project binary (default "$HOME/.pdtm/go/bin")
+   -nsp, -no-set-path        don't add path to environment variables
 
 INSTALL:
    -i, -install string[]  install single or multiple project by name (comma separated)
@@ -77,9 +78,10 @@ REMOVE:
    -ra, -remove-all      remove all the projects
 
 DEBUG:
-   -nc, -no-color            disable output content coloring (ANSI escape codes)
-   -version  show version of the project
-   -v        show verbose output
+   -show-path      prints the current binaries path then exit
+   -version        show version of the project
+   -v              show verbose output
+   -nc, -no-color  disable output content coloring (ANSI escape codes)
 ```
 
 ## Running pdtm

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -25,6 +25,7 @@ type Options struct {
 	ConfigFile string
 	Path       string
 	NoColor    bool
+	NoSetPath  bool
 
 	Install goflags.StringSlice
 	Update  goflags.StringSlice
@@ -53,6 +54,7 @@ func ParseOptions() *Options {
 	flagSet.CreateGroup("config", "Config",
 		flagSet.StringVar(&options.ConfigFile, "config", defaultConfigLocation, "cli flag configuration file"),
 		flagSet.StringVarP(&options.Path, "binary-path", "bp", defaultPath, "custom location to download project binary"),
+		flagSet.BoolVarP(&options.NoSetPath, "no-set-path", "nsp", false, "don't add path to environment variables"),
 	)
 
 	flagSet.CreateGroup("install", "Install",
@@ -104,9 +106,9 @@ func ParseOptions() *Options {
 		gologger.Fatal().Msgf("pdtm error: %s\n", err)
 	}
 
-	if options.Path == defaultPath {
+	if options.Path == defaultPath && !options.NoSetPath {
 		if err := path.SetENV(defaultPath); err != nil {
-			gologger.Fatal().Msgf("Failed to set path: %s. Add ~/.pdtm/go/bin/ to $PATH and run again", err)
+			gologger.Warning().Msgf("Failed to set path: %s. Add ~/.pdtm/go/bin/ to $PATH and run again", err)
 		}
 
 	}

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -35,9 +35,10 @@ type Options struct {
 	UpdateAll  bool
 	RemoveAll  bool
 
-	Verbose bool
-	Silent  bool
-	Version bool
+	Verbose  bool
+	Silent   bool
+	Version  bool
+	ShowPath bool
 }
 
 // ParseOptions parses the command line flags provided by a user
@@ -73,6 +74,7 @@ func ParseOptions() *Options {
 	)
 
 	flagSet.CreateGroup("debug", "Debug",
+		flagSet.BoolVar(&options.ShowPath, "show-path", false, "prints the current binaries path then exit"),
 		flagSet.BoolVar(&options.Version, "version", false, "show version of the project"),
 		flagSet.BoolVar(&options.Verbose, "v", false, "show verbose output"),
 		flagSet.BoolVarP(&options.NoColor, "no-color", "nc", false, "disable output content coloring (ANSI escape codes)"),
@@ -92,6 +94,12 @@ func ParseOptions() *Options {
 
 	if options.Version {
 		gologger.Info().Msgf("Current Version: %s\n", Version)
+		os.Exit(0)
+	}
+
+	if options.ShowPath {
+		// prints default path if not modified
+		gologger.Silent().Msg(options.Path)
 		os.Exit(0)
 	}
 

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -55,7 +55,7 @@ func ParseOptions() *Options {
 	flagSet.CreateGroup("config", "Config",
 		flagSet.StringVar(&options.ConfigFile, "config", defaultConfigLocation, "cli flag configuration file"),
 		flagSet.StringVarP(&options.Path, "binary-path", "bp", defaultPath, "custom location to download project binary"),
-		flagSet.BoolVarP(&options.NoSetPath, "no-set-path", "nsp", false, "don't add path to environment variables"),
+		flagSet.BoolVarP(&options.NoSetPath, "no-set-path", "nsp", false, "disable adding path to environment variables"),
 	)
 
 	flagSet.CreateGroup("install", "Install",
@@ -74,9 +74,9 @@ func ParseOptions() *Options {
 	)
 
 	flagSet.CreateGroup("debug", "Debug",
-		flagSet.BoolVar(&options.ShowPath, "show-path", false, "prints the current binaries path then exit"),
+		flagSet.BoolVarP(&options.ShowPath, "show-path", "sp", false, "show the current binary path then exit"),
 		flagSet.BoolVar(&options.Version, "version", false, "show version of the project"),
-		flagSet.BoolVar(&options.Verbose, "v", false, "show verbose output"),
+		flagSet.BoolVarP(&options.Verbose, "verbose", "v", false, "show verbose output"),
 		flagSet.BoolVarP(&options.NoColor, "no-color", "nc", false, "disable output content coloring (ANSI escape codes)"),
 	)
 

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -56,17 +56,17 @@ func ParseOptions() *Options {
 	)
 
 	flagSet.CreateGroup("install", "Install",
-		flagSet.StringSliceVarP(&options.Install, "install", "i", []string{}, "install single or multiple project by name (comma separated)", goflags.NormalizedStringSliceOptions),
+		flagSet.StringSliceVarP(&options.Install, "install", "i", nil, "install single or multiple project by name (comma separated)", goflags.NormalizedStringSliceOptions),
 		flagSet.BoolVarP(&options.InstallAll, "install-all", "ia", false, "install all the projects"),
 	)
 
 	flagSet.CreateGroup("update", "Update",
-		flagSet.StringSliceVarP(&options.Update, "update", "u", []string{}, "update single or multiple project by name (comma separated)", goflags.NormalizedStringSliceOptions),
+		flagSet.StringSliceVarP(&options.Update, "update", "u", nil, "update single or multiple project by name (comma separated)", goflags.NormalizedStringSliceOptions),
 		flagSet.BoolVarP(&options.UpdateAll, "update-all", "ua", false, "update all the projects"),
 	)
 
 	flagSet.CreateGroup("remove", "Remove",
-		flagSet.StringSliceVarP(&options.Remove, "remove", "r", []string{}, "remove single or multiple project by name (comma separated)", goflags.NormalizedStringSliceOptions),
+		flagSet.StringSliceVarP(&options.Remove, "remove", "r", nil, "remove single or multiple project by name (comma separated)", goflags.NormalizedStringSliceOptions),
 		flagSet.BoolVarP(&options.RemoveAll, "remove-all", "ra", false, "remove all the projects"),
 	)
 


### PR DESCRIPTION
Closes #10

Notes:
- interactsh will be indirectly fixed with https://github.com/projectdiscovery/interactsh/issues/444
- Adding path to env vars is now non-fatal (and it shouldn't be performed automatically without user authorization)

The PR only covers tools setup and emulates env path, the latter will be handled in a follow up task