### PR TITLE
blacklist on pdtm related to pdtm-api

### DIFF
--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -11,7 +11,6 @@ import (
 	"github.com/projectdiscovery/gologger/levels"
 	fileutil "github.com/projectdiscovery/utils/file"
 	updateutils "github.com/projectdiscovery/utils/update"
-
 )
 
 var (

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -12,7 +12,10 @@ import (
 	"github.com/projectdiscovery/pdtm/pkg/path"
 	"github.com/projectdiscovery/pdtm/pkg/utils"
 	errorutil "github.com/projectdiscovery/utils/errors"
+	stringsutil "github.com/projectdiscovery/utils/strings"
 )
+
+var blacklistTool = []string{"nuclei-templates"}
 
 // Runner contains the internal logic of the program
 type Runner struct {
@@ -41,7 +44,14 @@ func (r *Runner) Run() error {
 		}
 	}
 
-	toolList, err := utils.FetchToolList()
+	toolListApi, err := utils.FetchToolList()
+	var toolList []pkg.Tool
+
+	for _, tool := range toolListApi {
+		if !stringsutil.ContainsAny(tool.Name, blacklistTool...) {
+			toolList = append(toolList, tool)
+		}
+	}
 
 	// if toolList is not nil save/update the cache
 	// else fetch from cache file


### PR DESCRIPTION
`var blacklistTool = []string{"nuclei-templates"}`

```
./pdtm

                ____          
     ____  ____/ / /_____ ___ 
    / __ \/ __  / __/ __ __  \
   / /_/ / /_/ / /_/ / / / / /
  / .___/\__,_/\__/_/ /_/ /_/ 
 /_/                         

		projectdiscovery.io

[INF] Current pdtm version v0.0.5 (latest)
[INF] [OS: DARWIN] [ARCH: AMD64] [GO: 1.20.2]
[INF] Path to download project binary: /Users/geekboy/.pdtm/go/bin
[INF] Path /Users/geekboy/.pdtm/go/bin configured in environment variable $PATH
1. aix (latest) (0.0.1)
2. subfinder (latest) (2.5.7)
3. dnsx (latest) (1.1.3)
4. naabu (latest) (2.1.5)
5. httpx (latest) (1.2.9)
6. nuclei (latest) (2.9.1)
7. nuclei-templates (not supported) // WILL BE REMOVED FROM THIS LIST
8. uncover (latest) (1.0.3)
```