### PR TITLE
Improving version detection + minor changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /pdtm
 dist/
+.idea
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+# Go parameters
+GOCMD=go
+GOBUILD=$(GOCMD) build
+GOMOD=$(GOCMD) mod
+GOTEST=$(GOCMD) test
+GOFLAGS := -v
+# This should be disabled if the binary uses pprof
+LDFLAGS := -s -w
+
+ifneq ($(shell go env GOOS),darwin)
+LDFLAGS := -extldflags "-static"
+endif
+    
+all: build
+build:
+	$(GOBUILD) $(GOFLAGS) -ldflags '$(LDFLAGS)' -o "pdtm" cmd/pdtm/pdtm.go
+test:
+	$(GOTEST) $(GOFLAGS) ./...
+tidy:
+	$(GOMOD) tidy

--- a/internal/runner/banner.go
+++ b/internal/runner/banner.go
@@ -7,14 +7,14 @@ import (
 
 const version = "v0.0.6"
 
-var banner = (`
+var banner = `
                 ____          
      ____  ____/ / /_____ ___ 
     / __ \/ __  / __/ __ __  \
    / /_/ / /_/ / /_/ / / / / /
   / .___/\__,_/\__/_/ /_/ /_/ 
  /_/                         
-`)
+`
 
 // showBanner is used to show the banner to the user
 func showBanner() {

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -146,6 +146,6 @@ func (options *Options) configureOutput() {
 	}
 }
 
-func (Options *Options) loadConfigFrom(location string) error {
-	return fileutil.Unmarshal(fileutil.YAML, []byte(location), Options)
+func (options *Options) loadConfigFrom(location string) error {
+	return fileutil.Unmarshal(fileutil.YAML, []byte(location), options)
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -10,6 +10,7 @@ import (
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/pdtm/pkg"
 	"github.com/projectdiscovery/pdtm/pkg/path"
+	"github.com/projectdiscovery/pdtm/pkg/types"
 	"github.com/projectdiscovery/pdtm/pkg/utils"
 	errorutil "github.com/projectdiscovery/utils/errors"
 	stringsutil "github.com/projectdiscovery/utils/strings"
@@ -45,7 +46,7 @@ func (r *Runner) Run() error {
 	}
 
 	toolListApi, err := utils.FetchToolList()
-	var toolList []pkg.Tool
+	var toolList []types.Tool
 
 	for _, tool := range toolListApi {
 		if !stringsutil.ContainsAny(tool.Name, blacklistTool...) {
@@ -97,7 +98,7 @@ func (r *Runner) Run() error {
 		}
 		if i, ok := utils.Contains(toolList, tool); ok {
 			if err := pkg.Install(r.options.Path, toolList[i]); err != nil {
-				if err == pkg.ErrIsInstalled {
+				if err == types.ErrIsInstalled {
 					gologger.Info().Msgf("%s: %s", tool, err)
 				} else {
 					gologger.Error().Msgf("error while installing %s: %s", tool, err)
@@ -114,7 +115,7 @@ func (r *Runner) Run() error {
 		}
 		if i, ok := utils.Contains(toolList, tool); ok {
 			if err := pkg.Update(r.options.Path, toolList[i]); err != nil {
-				if err == pkg.ErrIsUpToDate {
+				if err == types.ErrIsUpToDate {
 					gologger.Info().Msgf("%s: %s", tool, err)
 				} else {
 					gologger.Info().Msgf("%s\n", err)
@@ -146,7 +147,7 @@ func (r *Runner) Run() error {
 }
 
 // UpdateCache creates/updates cache file
-func UpdateCache(toolList []pkg.Tool) error {
+func UpdateCache(toolList []types.Tool) error {
 	b, err := json.Marshal(toolList)
 	if err != nil {
 		return err
@@ -155,12 +156,12 @@ func UpdateCache(toolList []pkg.Tool) error {
 }
 
 // FetchFromCache loads tool list from cache file
-func FetchFromCache() ([]pkg.Tool, error) {
+func FetchFromCache() ([]types.Tool, error) {
 	b, err := os.ReadFile(cacheFile)
 	if err != nil {
 		return nil, err
 	}
-	var toolList []pkg.Tool
+	var toolList []types.Tool
 	if err := json.Unmarshal(b, &toolList); err != nil {
 		return nil, err
 	}
@@ -168,7 +169,7 @@ func FetchFromCache() ([]pkg.Tool, error) {
 }
 
 // ListToolsAndEnv prints the list of tools
-func (r *Runner) ListToolsAndEnv(tools []pkg.Tool) error {
+func (r *Runner) ListToolsAndEnv(tools []types.Tool) error {
 	gologger.Info().Msgf(path.GetOsData() + "\n")
 	gologger.Info().Msgf("Path to download project binary: %s\n", r.options.Path)
 	var fmtMsg string

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -56,7 +56,11 @@ func (r *Runner) Run() error {
 	// if toolList is not nil save/update the cache
 	// else fetch from cache file
 	if toolList != nil {
-		go UpdateCache(toolList) //nolint:errcheck
+		go func() {
+			if err := UpdateCache(toolList); err != nil {
+				gologger.Warning().Msgf("%s\n", err)
+			}
+		}()
 	} else {
 		toolList, err = FetchFromCache()
 		if err != nil {
@@ -163,7 +167,7 @@ func FetchFromCache() ([]pkg.Tool, error) {
 	return toolList, nil
 }
 
-// ListTools prints the list of tools
+// ListToolsAndEnv prints the list of tools
 func (r *Runner) ListToolsAndEnv(tools []pkg.Tool) error {
 	gologger.Info().Msgf(path.GetOsData() + "\n")
 	gologger.Info().Msgf("Path to download project binary: %s\n", r.options.Path)

--- a/pkg/crud_test.go
+++ b/pkg/crud_test.go
@@ -4,11 +4,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/projectdiscovery/pdtm/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
-func GetToolStruct() Tool {
-	tool := Tool{
+func GetToolStruct() types.Tool {
+	tool := types.Tool{
 		Name:    "dnsx",
 		Repo:    "dnsx",
 		Version: "1.1.1",

--- a/pkg/install.go
+++ b/pkg/install.go
@@ -19,6 +19,7 @@ import (
 	"github.com/logrusorgru/aurora/v4"
 	"github.com/projectdiscovery/gologger"
 	ospath "github.com/projectdiscovery/pdtm/pkg/path"
+	"github.com/projectdiscovery/pdtm/pkg/types"
 )
 
 var (
@@ -27,9 +28,9 @@ var (
 )
 
 // Install installs given tool at path
-func Install(path string, tool Tool) error {
+func Install(path string, tool types.Tool) error {
 	if _, exists := ospath.GetExecutablePath(path, tool.Name); exists {
-		return ErrIsInstalled
+		return types.ErrIsInstalled
 	}
 	gologger.Info().Msgf("installing %s...", tool.Name)
 	version, err := install(tool, path)
@@ -40,7 +41,7 @@ func Install(path string, tool Tool) error {
 	return nil
 }
 
-func install(tool Tool, path string) (string, error) {
+func install(tool types.Tool, path string) (string, error) {
 	builder := &strings.Builder{}
 	builder.WriteString(tool.Name)
 	builder.WriteString("_")
@@ -76,10 +77,10 @@ loop:
 
 	// handle if id is zero (no asset found)
 	if id == 0 {
-		return "", fmt.Errorf(ErrNoAssetFound, runtime.GOOS, runtime.GOARCH)
+		return "", fmt.Errorf(types.ErrNoAssetFound, runtime.GOOS, runtime.GOARCH)
 	}
 
-	_, rdurl, err := GithubClient().Repositories.DownloadReleaseAsset(context.Background(), Organization, tool.Repo, int64(id))
+	_, rdurl, err := GithubClient().Repositories.DownloadReleaseAsset(context.Background(), types.Organization, tool.Repo, int64(id))
 	if err != nil {
 		if arlErr, ok := err.(*github.AbuseRateLimitError); ok {
 			// Provide user with more info regarding the rate limit

--- a/pkg/path/path.go
+++ b/pkg/path/path.go
@@ -1,6 +1,7 @@
 package path
 
 import (
+	osutils "github.com/projectdiscovery/utils/os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -61,7 +62,7 @@ func GetExecutablePath(path, toolName string) (string, bool) {
 		}
 	}
 
-	if runtime.GOOS == "windows" {
+	if osutils.IsWindows() {
 		return basePath + ".exe", false
 	}
 

--- a/pkg/path/path.go
+++ b/pkg/path/path.go
@@ -1,10 +1,11 @@
 package path
 
 import (
-	osutils "github.com/projectdiscovery/utils/os"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	osutils "github.com/projectdiscovery/utils/os"
 
 	fileutil "github.com/projectdiscovery/utils/file"
 )

--- a/pkg/path/windows.go
+++ b/pkg/path/windows.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-// from https://github.com/therootcompany/pathman with some minor changes
+// path from https://github.com/therootcompany/pathman with some minor changes
 package path
 
 // Needs to
@@ -70,13 +70,13 @@ func remove(p string) (bool, error) {
 func write(path string, cur []string) error {
 	k, err := registry.OpenKey(registry.CURRENT_USER, `Environment`, registry.SET_VALUE)
 	if err != nil {
-		return fmt.Errorf("Can't open HKCU Environment for writes: %s", err)
+		return fmt.Errorf("can't open HKCU Environment for writes: %s", err)
 	}
 	defer k.Close()
 
 	err = k.SetStringValue(`Path`, strings.Join(cur, string(os.PathListSeparator)))
 	if nil != err {
-		return fmt.Errorf("Can't set HKCU Environment[Path]: %s", err)
+		return fmt.Errorf("can't set HKCU Environment[Path]: %s", err)
 	}
 	err = k.Close()
 	if nil != err {
@@ -102,7 +102,7 @@ func paths() []string {
 func getPathsFromRegistry() ([]string, error) {
 	k, err := registry.OpenKey(registry.CURRENT_USER, `Environment`, registry.QUERY_VALUE)
 	if err != nil {
-		return nil, fmt.Errorf("Can't open HKCU Environment for reads: %s", err)
+		return nil, fmt.Errorf("can't open HKCU Environment for reads: %s", err)
 	}
 	defer k.Close()
 	s, _, err := k.GetStringValue("Path")
@@ -110,7 +110,7 @@ func getPathsFromRegistry() ([]string, error) {
 		if strings.Contains(err.Error(), "cannot find the file") {
 			return []string{}, nil
 		}
-		return nil, fmt.Errorf("Can't query HKCU Environment[Path]: %s", err)
+		return nil, fmt.Errorf("can't query HKCU Environment[Path]: %s", err)
 	}
 	return strings.Split(s, string(os.PathListSeparator)), nil
 }

--- a/pkg/path/winpath.go
+++ b/pkg/path/winpath.go
@@ -1,4 +1,4 @@
-// Package winpath is useful for managing PATH as part of the Environment
+// Package path is useful for managing PATH as part of the Environment
 // in the Windows HKey Local User registry. It returns an error for most
 // operations on non-Windows systems.
 package path

--- a/pkg/path/winpath_unsafe.go
+++ b/pkg/path/winpath_unsafe.go
@@ -1,5 +1,4 @@
 //go:build windows && !nounsafe
-// +build windows,!nounsafe
 
 package path
 

--- a/pkg/remove.go
+++ b/pkg/remove.go
@@ -5,12 +5,13 @@ import (
 	"os"
 
 	ospath "github.com/projectdiscovery/pdtm/pkg/path"
+	"github.com/projectdiscovery/pdtm/pkg/types"
 
 	"github.com/projectdiscovery/gologger"
 )
 
 // Remove removes given tool
-func Remove(path string, tool Tool) error {
+func Remove(path string, tool types.Tool) error {
 	executablePath, exists := ospath.GetExecutablePath(path, tool.Name)
 	if exists {
 		gologger.Info().Msgf("removing %s...", tool.Name)
@@ -21,5 +22,5 @@ func Remove(path string, tool Tool) error {
 		gologger.Info().Msgf("removed %s", tool.Name)
 		return nil
 	}
-	return fmt.Errorf(ErrToolNotFound, tool.Name, executablePath)
+	return fmt.Errorf(types.ErrToolNotFound, tool.Name, executablePath)
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,8 +1,6 @@
-package pkg
+package types
 
-import (
-	"errors"
-)
+import "errors"
 
 const Organization = "projectdiscovery"
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -18,3 +18,8 @@ type Tool struct {
 	Version string            `json:"version"`
 	Assets  map[string]string `json:"assets"`
 }
+
+type NucleiData struct {
+	IgnoreHash string `json:"ignore-hash"`
+	Tools      []Tool `json:"tools"`
+}

--- a/pkg/utils/helpers.go
+++ b/pkg/utils/helpers.go
@@ -9,7 +9,7 @@ import (
 	"github.com/projectdiscovery/pdtm/pkg"
 )
 
-// returns a callback function and when it is executed returns a version string of that tool
+// GetVersionCheckCallback returns a callback function and when it is executed returns a version string of that tool
 func GetVersionCheckCallback(toolName, basePath string) func() string {
 	return func() string {
 		tool, err := fetchTool(toolName)
@@ -20,7 +20,7 @@ func GetVersionCheckCallback(toolName, basePath string) func() string {
 	}
 }
 
-// returns a callback function when executed  updates that tool
+// GetUpdaterCallback returns a callback function when executed  updates that tool
 func GetUpdaterCallback(toolName string) func() {
 	return func() {
 		home, _ := os.UserHomeDir()

--- a/pkg/utils/helpers.go
+++ b/pkg/utils/helpers.go
@@ -28,7 +28,8 @@ func GetUpdaterCallback(toolName string) func() {
 		dp := filepath.Join(home, ".pdtm/go/bin")
 		tool, err := fetchTool(toolName)
 		if err != nil {
-			gologger.Error().Msg(err.Error())
+			gologger.Error().Msgf("failed to fetch details of %v skipping update: %v", toolName, err)
+			return
 		}
 		err = pkg.Update(dp, tool)
 		if err == types.ErrIsUpToDate {

--- a/pkg/utils/helpers.go
+++ b/pkg/utils/helpers.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/pdtm/pkg"
+	"github.com/projectdiscovery/pdtm/pkg/types"
 )
 
 // GetVersionCheckCallback returns a callback function and when it is executed returns a version string of that tool
@@ -30,7 +31,7 @@ func GetUpdaterCallback(toolName string) func() {
 			gologger.Error().Msg(err.Error())
 		}
 		err = pkg.Update(dp, tool)
-		if err == pkg.ErrIsUpToDate {
+		if err == types.ErrIsUpToDate {
 			gologger.Info().Msgf("%s: %s", toolName, err)
 		} else {
 			gologger.Error().Msgf("error while updating %s: %s", toolName, err)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -58,7 +58,6 @@ func fetchTool(toolName string) (types.Tool, error) {
 	var tool types.Tool
 	// Create the request URL to get tool
 	reqURL := fmt.Sprintf("%s/api/v1/tools/%s?os=%s&arch=%s&go_version=%s", host, toolName, osName, osArch, goVersion)
-	fmt.Println(reqURL)
 	resp, err := http.Get(reqURL)
 	if err != nil {
 		return tool, err

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -32,7 +32,7 @@ func FetchToolList() ([]types.Tool, error) {
 	tools := make([]types.Tool, 0)
 
 	// Create the request URL with query parameters
-	reqURL := host + "/api/v1/tools?os=" + osName + "&arch=" + osArch + "&go_version=" + goVersion
+	reqURL := fmt.Sprintf("%s/api/v1/tools/?os=%s&arch=%s&go_version=%s", host, osName, osArch, goVersion)
 
 	resp, err := http.Get(reqURL)
 	if err != nil {
@@ -57,7 +57,8 @@ func FetchToolList() ([]types.Tool, error) {
 func fetchTool(toolName string) (types.Tool, error) {
 	var tool types.Tool
 	// Create the request URL to get tool
-	reqURL := host + "/api/v1/tools/" + toolName + "?os=" + osName + "&arch=" + osArch + "&go_version=" + goVersion
+	reqURL := fmt.Sprintf("%s/api/v1/tools/%s?os=%s&arch=%s&go_version=%s", host, toolName, osName, osArch, goVersion)
+	fmt.Println(reqURL)
 	resp, err := http.Get(reqURL)
 	if err != nil {
 		return tool, err

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 
@@ -85,6 +86,8 @@ func Contains(s []pkg.Tool, toolName string) (int, bool) {
 	return -1, false
 }
 
+var regexVersionNumber = regexp.MustCompile(`(?m)[v\s](\d+\.\d+\.\d+)`)
+
 func InstalledVersion(tool pkg.Tool, basePath string, au *aurora.Aurora) string {
 	var msg string
 
@@ -104,9 +107,8 @@ func InstalledVersion(tool pkg.Tool, basePath string, au *aurora.Aurora) string 
 		}
 	}
 
-	installedVersion := strings.Split(strings.ToLower(outb.String()), "current version: ")
-	if len(installedVersion) == 2 {
-		installedVersionString := strings.TrimPrefix(strings.TrimSpace(string(installedVersion[1])), "v")
+	if installedVersion := regexVersionNumber.FindString(strings.ToLower(outb.String())); installedVersion != "" {
+		installedVersionString := strings.TrimPrefix(strings.TrimSpace(installedVersion), "v")
 		if strings.Contains(tool.Version, installedVersionString) {
 			msg = fmt.Sprintf("(%s) (%s)", au.BrightGreen("latest").String(), au.BrightGreen(tool.Version).String())
 		} else {
@@ -116,6 +118,7 @@ func InstalledVersion(tool pkg.Tool, basePath string, au *aurora.Aurora) string 
 				au.BrightGreen(tool.Version).String())
 		}
 	}
+
 	return msg
 }
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,34 @@
+package version
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/projectdiscovery/pdtm/pkg/types"
+)
+
+var RegexVersionNumber = regexp.MustCompile(`(?m)[v\s](\d+\.\d+\.\d+)`)
+
+func ExtractInstalledVersion(tool types.Tool, basePath string) (string, error) {
+	toolPath := filepath.Join(basePath, tool.Name)
+	cmd := exec.Command(toolPath, "--version")
+
+	var outb bytes.Buffer
+	cmd.Stdout = &outb
+	cmd.Stderr = &outb
+	err := cmd.Run()
+	if err != nil {
+		return "", err
+	}
+
+	if installedVersion := RegexVersionNumber.FindString(strings.ToLower(outb.String())); installedVersion != "" {
+		installedVersionString := strings.TrimPrefix(strings.TrimSpace(installedVersion), "v")
+		return installedVersionString, nil
+	}
+
+	return "", errors.New("unable to extract installed version")
+}


### PR DESCRIPTION
Closes #127 

Example:
```console
$ go run .

                ____
     ____  ____/ / /_____ ___ 
    / __ \/ __  / __/ __ __  \
   / /_/ / /_/ / /_/ / / / / /
  / .___/\__,_/\__/_/ /_/ /_/ 
 /_/

                projectdiscovery.io

[INF] Current pdtm version v0.0.6 (latest)
[INF] [OS: WINDOWS] [ARCH: AMD64] [GO: 1.20.4]
[INF] Path to download project binary: C:\Users\user\.pdtm\go\bin
[INF] Path C:\Users\user\.pdtm\go\bin configured in environment variable $PATH
1. aix (latest) (0.0.2)
2. subfinder (outdated) (2.5.6) ➡ (2.5.8)
3. dnsx (outdated) (1.1.2) ➡ (1.1.4)
4. naabu (latest) (2.1.6)
5. httpx (outdated) (1.2.7) ➡ (1.3.0)
6. nuclei (latest) (2.9.3)
7. uncover (outdated) (1.0.2) ➡ (1.0.4)
8. cloudlist (outdated) (1.0.2) ➡ (1.0.3)
9. proxify (outdated) (0.0.8) ➡ (0.0.9)
10. tlsx (outdated) (1.0.5) ➡ (1.0.9)
11. notify (latest) (1.0.4)
12. chaos-client (outdated) (0.4.0) ➡ (0.5.1)
13. shuffledns (outdated) (1.0.8) ➡ (1.0.9)
14. mapcidr (outdated) (1.1.0) ➡ (1.1.1)
15. interactsh-client (outdated) (1.1.0) ➡ (1.1.3)
16. interactsh-server (latest) (1.1.3)
17. katana (outdated) (0.0.3) ➡ (1.0.1)
18. pdtm (latest) (0.0.6)
19. asnmap (latest) (1.0.3)
20. alterx (latest) (0.0.1)
21. cdncheck (latest) (1.0.0)
22. simplehttpserver (latest) (0.0.6)
```