### PR TITLE
Fix tool removal on the update for a tool having no assets

### DIFF
--- a/pkg/crud_test.go
+++ b/pkg/crud_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	ospath "github.com/projectdiscovery/pdtm/pkg/path"
 	"github.com/projectdiscovery/pdtm/pkg/types"
 	"github.com/stretchr/testify/require"
 )
@@ -95,13 +96,22 @@ func TestUpdateNonExistingTool(t *testing.T) {
 
 func TestUpdateToolWithoutAssets(t *testing.T) {
 	tool := GetToolStruct()
-	tool.Assets = nil
 
 	pathBin, err := os.MkdirTemp("", "test-dir")
 	require.Nil(t, err)
 	defer os.RemoveAll(pathBin)
 
-	// updating non existing tool should error
+	// install the tool
+	err = Install(pathBin, tool)
+	require.Nil(t, err)
+
+	// remove assets
+	tool.Assets = nil
+
+	// updating a tool without assets should trigger an error
 	err = Update(pathBin, tool, true)
 	require.NotNil(t, err)
+	// and leave the original binary in place
+	_, exists := ospath.GetExecutablePath(pathBin, tool.Name)
+	require.True(t, exists)
 }

--- a/pkg/crud_test.go
+++ b/pkg/crud_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/projectdiscovery/pdtm/pkg/types"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func GetToolStruct() types.Tool {
@@ -33,62 +33,75 @@ func TestInstall(t *testing.T) {
 	tool := GetToolStruct()
 
 	pathBin, err := os.MkdirTemp("", "test-dir")
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	defer os.RemoveAll(pathBin)
 
 	// install first time
 	err = Install(pathBin, tool)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	// installing again should trigger an error
 	err = Install(pathBin, tool)
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }
 
 func TestRemove(t *testing.T) {
 	tool := GetToolStruct()
 
 	pathBin, err := os.MkdirTemp("", "test-dir")
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	defer os.RemoveAll(pathBin)
 
 	// install the tool
 	err = Install(pathBin, tool)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	// remove it from path
 	err = Remove(pathBin, tool)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	// removing non existing tool triggers an error
 	err = Remove(pathBin, tool)
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }
 
 func TestUpdateSameVersion(t *testing.T) {
 	tool := GetToolStruct()
 
 	pathBin, err := os.MkdirTemp("", "test-dir")
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	defer os.RemoveAll(pathBin)
 
 	// install the tool
 	err = Install(pathBin, tool)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	// updating a tool to the same version should trigger an error
 	err = Update(pathBin, tool, true)
-	assert.Equal(t, "already up to date", err.Error())
+	require.Equal(t, "already up to date", err.Error())
 }
 
 func TestUpdateNonExistingTool(t *testing.T) {
 	tool := GetToolStruct()
 
 	pathBin, err := os.MkdirTemp("", "test-dir")
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	defer os.RemoveAll(pathBin)
 
 	// updating non existing tool should error
 	err = Update(pathBin, tool, true)
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
+}
+
+func TestUpdateToolWithoutAssets(t *testing.T) {
+	tool := GetToolStruct()
+	tool.Assets = nil
+
+	pathBin, err := os.MkdirTemp("", "test-dir")
+	require.Nil(t, err)
+	defer os.RemoveAll(pathBin)
+
+	// updating non existing tool should error
+	err = Update(pathBin, tool, true)
+	require.NotNil(t, err)
 }

--- a/pkg/update.go
+++ b/pkg/update.go
@@ -22,22 +22,23 @@ func Update(path string, tool types.Tool, disableChangeLog bool) error {
 		}
 		gologger.Info().Msgf("updating %s...", tool.Name)
 
-		if len(tool.Assets) > 0 {
-			if err := os.Remove(executablePath); err != nil {
-				return err
-			}
-
-			version, err := install(tool, path)
-			if err != nil {
-				return err
-			}
-			if !disableChangeLog {
-				showReleaseNotes(tool.Name)
-			}
-			gologger.Info().Msgf("updated %s to %s (%s)", tool.Name, version, au.BrightGreen("latest").String())
-			return nil
+		if len(tool.Assets) == 0 {
+			return fmt.Errorf(types.ErrNoAssetFound, tool.Name, executablePath)
 		}
-		return fmt.Errorf(types.ErrNoAssetFound, tool.Name, executablePath)
+
+		if err := os.Remove(executablePath); err != nil {
+			return err
+		}
+
+		version, err := install(tool, path)
+		if err != nil {
+			return err
+		}
+		if !disableChangeLog {
+			showReleaseNotes(tool.Name)
+		}
+		gologger.Info().Msgf("updated %s to %s (%s)", tool.Name, version, au.BrightGreen("latest").String())
+		return nil
 	} else {
 		return fmt.Errorf(types.ErrToolNotFound, tool.Name, executablePath)
 	}

--- a/pkg/update.go
+++ b/pkg/update.go
@@ -21,18 +21,23 @@ func Update(path string, tool types.Tool, disableChangeLog bool) error {
 			return types.ErrIsUpToDate
 		}
 		gologger.Info().Msgf("updating %s...", tool.Name)
-		if err := os.Remove(executablePath); err != nil {
-			return err
+
+		if len(tool.Assets) > 0 {
+			if err := os.Remove(executablePath); err != nil {
+				return err
+			}
+
+			version, err := install(tool, path)
+			if err != nil {
+				return err
+			}
+			if !disableChangeLog {
+				showReleaseNotes(tool.Name)
+			}
+			gologger.Info().Msgf("updated %s to %s (%s)", tool.Name, version, au.BrightGreen("latest").String())
+			return nil
 		}
-		version, err := install(tool, path)
-		if err != nil {
-			return err
-		}
-		if !disableChangeLog {
-			showReleaseNotes(tool.Name)
-		}
-		gologger.Info().Msgf("updated %s to %s (%s)", tool.Name, version, au.BrightGreen("latest").String())
-		return nil
+		return fmt.Errorf(types.ErrNoAssetFound, tool.Name, executablePath)
 	} else {
 		return fmt.Errorf(types.ErrToolNotFound, tool.Name, executablePath)
 	}


### PR DESCRIPTION
This PR prevents tool removal on the update for a tool having no assets. Closes #149.