### PR TITLE
Using repository name instead of binary name

### DIFF
--- a/pkg/update.go
+++ b/pkg/update.go
@@ -35,7 +35,7 @@ func Update(path string, tool types.Tool, disableChangeLog bool) error {
 			return err
 		}
 		if !disableChangeLog {
-			showReleaseNotes(tool.Name)
+			showReleaseNotes(tool.Repo)
 		}
 		gologger.Info().Msgf("updated %s to %s (%s)", tool.Name, version, au.BrightGreen("latest").String())
 		return nil


### PR DESCRIPTION
## Description
This PR replaces the binary tool name with the repository name, as GitHub allows to retrieve assets by repository name. Additionally, the binary name might not match the repository name (for example, interactsh has two binaries in the same repository with different names => reason why GH was returning 404).

```console
$ go run . -u interactsh-server

                ____          
     ____  ____/ / /_____ ___ 
    / __ \/ __  / __/ __ __  \
   / /_/ / /_/ / /_/ / / / / /
  / .___/\__,_/\__/_/ /_/ /_/ 
 /_/                         

                projectdiscovery.io

[INF] Current pdtm version v0.0.7 (latest)
[INF] Run `source ~/.bashrc` to add /Users/marcornvh/.pdtm/go/bin to $PATH 
[INF] updating interactsh-server...

                                                                              
  ## What's Changed                                                           
                                                                              
  ### 🐞 Bugs                                                                 
                                                                              
  • Fixed issue of random failure to obtain public ip + fallback to outbound  
  ip on fail by @Ice3man543 in                                                
  https://github.com/projectdiscovery/interactsh/pull/599                     
                                                                              
  ### 🎉 Features                                                             
                                                                              
  • Export generated payload URLs to file by @dogancanbakir in                
  https://github.com/projectdiscovery/interactsh/pull/569                     
                                                                              
  ## New Contributors                                                         
                                                                              
  • @dogancanbakir made their first contribution in                           
  https://github.com/projectdiscovery/interactsh/pull/569                     
                                                                              
  Full Changelog:                                                             
  https://github.com/projectdiscovery/interactsh/compare/v1.1.4...v1.1.5      


[INF] updated interactsh-server to 1.1.5 (latest)
```

Closes #169 