### PR TITLE
add go install support as fallback

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -101,6 +101,7 @@ func (r *Runner) Run() error {
 			continue
 		}
 		if i, ok := utils.Contains(toolList, toolName); ok {
+			tool := getTool(toolName, toolList)
 			if err := pkg.Install(r.options.Path, toolList[i]); err != nil {
 				if err == types.ErrIsInstalled {
 					gologger.Info().Msgf("%s: %s", toolName, err)
@@ -109,14 +110,12 @@ func (r *Runner) Run() error {
 				}
 
 				gologger.Info().Msgf("trying to install %s using go install", toolName)
-				if err := fallbackGoInstall(toolName); err != nil {
+				if err := fallbackGoInstall(tool); err != nil {
 					gologger.Error().Msgf("error while installing %s using go install: %s", toolName, err)
 				} else {
 					gologger.Info().Msgf("successfully installed %s using go install", toolName)
 				}
-
 			}
-			tool := getTool(toolName, toolList)
 			printRequirementInfo(tool)
 		} else {
 			gologger.Error().Msgf("error while installing %s: %s not found in the list", toolName, toolName)
@@ -160,13 +159,10 @@ func (r *Runner) Run() error {
 	return nil
 }
 
-func fallbackGoInstall(toolName string) error {
-	cmd := exec.Command("go", "install", "-v", fmt.Sprintf("github.com/projectdiscovery/%s/v2/cmd/%s@latest", toolName, toolName))
-	if _, err := cmd.CombinedOutput(); err != nil {
-		cmd = exec.Command("go", "install", "-v", fmt.Sprintf("github.com/projectdiscovery/%s/cmd/%s@latest", toolName, toolName))
-		if output, err := cmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("go install failed for %s: %s", toolName, string(output))
-		}
+func fallbackGoInstall(tool *types.Tool) error {
+	cmd := exec.Command("go", "install", "-v", fmt.Sprintf("github.com/projectdiscovery/%s/%s", tool.Name, tool.GoInstallPath))
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("go install failed for %s: %s", tool.Name, string(output))
 	}
 	return nil
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -159,11 +159,8 @@ func (r *Runner) Run() error {
 }
 
 func fallbackGoInstall(tool *types.Tool) error {
-	err := os.Setenv("GOBIN", defaultPath)
-	if err != nil {
-		return fmt.Errorf("failed to set GOBIN: %s", err)
-	}
 	cmd := exec.Command("go", "install", "-v", fmt.Sprintf("github.com/projectdiscovery/%s/%s", tool.Name, tool.GoInstallPath))
+	cmd.Env = append(os.Environ(), "GOBIN="+defaultPath)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("go install failed for %s: %s", tool.Name, string(output))
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -103,17 +103,16 @@ func (r *Runner) Run() error {
 		if i, ok := utils.Contains(toolList, toolName); ok {
 			tool := getTool(toolName, toolList)
 			if err := pkg.Install(r.options.Path, toolList[i]); err != nil {
-				if err == types.ErrIsInstalled {
+				if errors.Is(err, types.ErrIsInstalled) {
 					gologger.Info().Msgf("%s: %s", toolName, err)
 				} else {
 					gologger.Error().Msgf("error while installing %s: %s", toolName, err)
-				}
-
-				gologger.Info().Msgf("trying to install %s using go install", toolName)
-				if err := fallbackGoInstall(tool); err != nil {
-					gologger.Error().Msgf("error while installing %s using go install: %s", toolName, err)
-				} else {
-					gologger.Info().Msgf("successfully installed %s using go install", toolName)
+					gologger.Info().Msgf("trying to install %s using go install", toolName)
+					if err := fallbackGoInstall(tool); err != nil {
+						gologger.Error().Msgf("error while installing %s using go install: %s", toolName, err)
+					} else {
+						gologger.Info().Msgf("successfully installed %s using go install", toolName)
+					}
 				}
 			}
 			printRequirementInfo(tool)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -160,6 +160,10 @@ func (r *Runner) Run() error {
 }
 
 func fallbackGoInstall(tool *types.Tool) error {
+	err := os.Setenv("GOBIN", defaultPath)
+	if err != nil {
+		return fmt.Errorf("failed to set GOBIN: %s", err)
+	}
 	cmd := exec.Command("go", "install", "-v", fmt.Sprintf("github.com/projectdiscovery/%s/%s", tool.Name, tool.GoInstallPath))
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("go install failed for %s: %s", tool.Name, string(output))

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -13,11 +13,12 @@ var (
 )
 
 type Tool struct {
-	Name         string            `json:"name"`
-	Repo         string            `json:"repo"`
-	Version      string            `json:"version"`
-	Requirements []ToolRequirement `json:"requirements"`
-	Assets       map[string]string `json:"assets"`
+	Name          string            `json:"name"`
+	Repo          string            `json:"repo"`
+	Version       string            `json:"version"`
+	GoInstallPath string            `json:"go_install_path" yaml:"go_install_path"`
+	Requirements  []ToolRequirement `json:"requirements"`
+	Assets        map[string]string `json:"assets"`
 }
 
 type ToolRequirement struct {


### PR DESCRIPTION
Closes #193.

```console
$ go run . -i notify

                ____          
     ____  ____/ / /_____ ___ 
    / __ \/ __  / __/ __ __  \
   / /_/ / /_/ / /_/ / / / / /
  / .___/\__,_/\__/_/ /_/ /_/ 
 /_/                         

                projectdiscovery.io

[INF] Current pdtm version v0.0.8 (latest)
[ERR] error while installing notify: not implemented
[INF] trying to install notify using go install
[INF] successfully installed notify using go install
```