### PR TITLE
append lib exts

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -15,6 +15,7 @@ import (
 	"github.com/projectdiscovery/pdtm/pkg/types"
 	"github.com/projectdiscovery/pdtm/pkg/utils"
 	errorutil "github.com/projectdiscovery/utils/errors"
+	osutils "github.com/projectdiscovery/utils/os"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 	"github.com/projectdiscovery/utils/syscallutil"
 )
@@ -264,12 +265,12 @@ func requirementSatisfied(requirementName string) bool {
 }
 
 func appendLibExtensionForOS(lib string) []string {
-	switch runtime.GOOS {
-	case "windows":
+	switch {
+	case osutils.IsWindows():
 		return []string{fmt.Sprintf("%s.dll", lib), lib}
-	case "linux":
+	case osutils.IsLinux():
 		return []string{fmt.Sprintf("%s.so", lib), lib}
-	case "darwin":
+	case osutils.IsOSX():
 		return []string{fmt.Sprintf("%s.dylib", lib), lib}
 	default:
 		return []string{lib}


### PR DESCRIPTION
Closes #200.

```console
$ ldconfig -p | grep libpcap
        libpcap.so.0.8 (libc6,AArch64) => /usr/lib/aarch64-linux-gnu/libpcap.so.0.8
        libpcap.so (libc6,AArch64) => /usr/lib/aarch64-linux-gnu/libpcap.so

$ go run . -i naabu

                ____          
     ____  ____/ / /_____ ___ 
    / __ \/ __  / __/ __ __  \
   / /_/ / /_/ / /_/ / / / / /
  / .___/\__,_/\__/_/ /_/ /_/ 
 /_/                         

                projectdiscovery.io

[INF] Current pdtm version v0.0.8 (latest)
[INF] installing naabu...
[ERR] error while installing naabu: could not find release asset for your platform (linux/arm64)
[INF] naabu requirements:
optional To install nmap on Linux, visit https://nmap.org/download.html and follow the instructions for your distribution.
Note: nmap is not required for naabu, so you can skip this step if you don't need it.
```

```console
$ ldconfig -p | grep libpcap

$ go run . -i naabu

                ____          
     ____  ____/ / /_____ ___ 
    / __ \/ __  / __/ __ __  \
   / /_/ / /_/ / /_/ / / / / /
  / .___/\__,_/\__/_/ /_/ /_/ 
 /_/                         

                projectdiscovery.io

[INF] Current pdtm version v0.0.8 (latest)
[INF] installing naabu...
[ERR] error while installing naabu: could not find release asset for your platform (linux/arm64)
[INF] naabu requirements:
required To install libpcap on Linux, run the following command in the terminal: sudo apt install -y libpcap-dev
optional To install nmap on Linux, visit https://nmap.org/download.html and follow the instructions for your distribution.
Note: nmap is not required for naabu, so you can skip this step if you don't need it.
```