### PR TITLE
introduce `install-go-path` flag

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
 
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Run golangci-lint

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -18,7 +18,7 @@ jobs:
       - name: "Set up Go"
         uses: actions/setup-go@v4
         with: 
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
           cache: true
       

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
       
       - name: release test
         uses: goreleaser/goreleaser-action@v4

--- a/.github/workflows/setup-test.yaml
+++ b/.github/workflows/setup-test.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
 
       - name: Check out code
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ CONFIG:
    -bp, -binary-path string  custom location to download project binary (default "$HOME/.pdtm/go/bin")
 
 INSTALL:
-   -i, -install string[]  install single or multiple project by name (comma separated)
-   -ia, -install-all      install all the projects
-   -ip, -install-path     append path to PATH environment variables
+   -i, -install string[]   install single or multiple project by name (comma separated)
+   -ia, -install-all       install all the projects
+   -ip, -install-path      append path to PATH environment variables
+   -igp, -install-go-path  append GOBIN/GOPATH to PATH environment variables
 
 UPDATE:
    -u, -update string[]         update single or multiple project by name (comma separated)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/projectdiscovery/pdtm
 
-go 1.20
+go 1.21
+
 
 require (
 	github.com/charmbracelet/glamour v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,7 @@ github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-github/v30 v30.1.0 h1:VLDx+UolQICEOKu2m4uAoMti1SxuEBAl7RSEG16L+Oo=
@@ -162,6 +163,7 @@ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAG
 golang.org/x/oauth2 v0.13.0 h1:jDDenyj+WgFtmV3zYVoi8aE2BwtXFLWOA67ZfNWftiY=
 golang.org/x/oauth2 v0.13.0/go.mod h1:/JMhi4ZRXAf4HG9LiNmxvk+45+96RUlVThiH8FzNBn0=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -36,6 +36,7 @@ type Options struct {
 	Path       string
 	NoColor    bool
 	SetPath    bool
+	SetGoPath  bool
 	UnSetPath  bool
 
 	Install goflags.StringSlice
@@ -70,6 +71,7 @@ func ParseOptions() *Options {
 		flagSet.StringSliceVarP(&options.Install, "install", "i", nil, "install single or multiple project by name (comma separated)", goflags.NormalizedStringSliceOptions),
 		flagSet.BoolVarP(&options.InstallAll, "install-all", "ia", false, "install all the projects"),
 		flagSet.BoolVarP(&options.SetPath, "install-path", "ip", false, "append path to PATH environment variables"),
+		flagSet.BoolVarP(&options.SetGoPath, "install-go-path", "igp", false, "append GOBIN/GOPATH to PATH environment variables"),
 	)
 
 	flagSet.CreateGroup("update", "Update",

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -43,6 +43,19 @@ func (r *Runner) Run() error {
 		}
 	}
 
+	if r.options.SetGoPath {
+		goBinEnvVar, goPathEnvVar := getGoEnv("GOBIN"), getGoEnv("GOPATH")
+		goEnvVar := goBinEnvVar
+		if goEnvVar == "" {
+			goEnvVar = goPathEnvVar
+		}
+		if goEnvVar != "" {
+			if err := path.SetENV(goEnvVar); err != nil {
+				return errorutil.NewWithErr(err).Msgf(`Failed to set path: %s. Add it to $PATH and run again`, goEnvVar)
+			}
+		}
+	}
+
 	if r.options.UnSetPath {
 		if err := path.UnsetENV(r.options.Path); err != nil {
 			return errorutil.NewWithErr(err).Msgf(`Failed to unset path: %s. Remove it from $PATH and run again`, r.options.Path)
@@ -162,6 +175,15 @@ func (r *Runner) Run() error {
 		return r.ListToolsAndEnv(toolList)
 	}
 	return nil
+}
+
+func getGoEnv(key string) string {
+	cmd := exec.Command("go", "env", key)
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
 }
 
 func isGoInstalled() bool {


### PR DESCRIPTION
Closes #203

```console
go run . -igp  

                ____          
     ____  ____/ / /_____ ___ 
    / __ \/ __  / __/ __ __  \
   / /_/ / /_/ / /_/ / / / / /
  / .___/\__,_/\__/_/ /_/ /_/ 
 /_/                         

                projectdiscovery.io

[INF] Current pdtm version v0.0.9 (latest)
[INF] Run `source ~/.zshrc` to add /Users/dogancanbakir/.pdtm/go/bin to $PATH 
[INF] Run `source ~/.zshrc` to add /Users/dogancanbakir/go to $PATH 
[INF] [OS: DARWIN] [ARCH: ARM64] [GO: 1.21.3]
[INF] Path to download project binary: /Users/dogancanbakir/.pdtm/go/bin
[INF] Path /Users/dogancanbakir/.pdtm/go/bin not configured in environment variable $PATH
...
```