### PR TITLE
fix linting.

### DIFF
--- a/pkg/crud_test.go
+++ b/pkg/crud_test.go
@@ -93,7 +93,9 @@ func TestUpdateNonExistingTool(t *testing.T) {
 
 	pathBin, err := os.MkdirTemp("", "test-dir")
 	require.Nil(t, err)
-	defer os.RemoveAll(pathBin)
+	defer func() {
+		require.NoError(t, os.RemoveAll(pathBin))
+	}()
 
 	// updating non existing tool should error
 	err = Update(pathBin, tool, true)
@@ -105,7 +107,9 @@ func TestUpdateToolWithoutAssets(t *testing.T) {
 
 	pathBin, err := os.MkdirTemp("", "test-dir")
 	require.Nil(t, err)
-	defer os.RemoveAll(pathBin)
+	defer func() {
+		require.NoError(t, os.RemoveAll(pathBin))
+	}()
 
 	// install the tool
 	err = Install(pathBin, tool)

--- a/pkg/crud_test.go
+++ b/pkg/crud_test.go
@@ -35,7 +35,9 @@ func TestInstall(t *testing.T) {
 
 	pathBin, err := os.MkdirTemp("", "test-dir")
 	require.Nil(t, err)
-	defer os.RemoveAll(pathBin)
+	defer func() {
+		require.NoError(t, os.RemoveAll(pathBin))
+	}()
 
 	// install first time
 	err = Install(pathBin, tool)
@@ -51,7 +53,9 @@ func TestRemove(t *testing.T) {
 
 	pathBin, err := os.MkdirTemp("", "test-dir")
 	require.Nil(t, err)
-	defer os.RemoveAll(pathBin)
+	defer func() {
+		require.NoError(t, os.RemoveAll(pathBin))
+	}()
 
 	// install the tool
 	err = Install(pathBin, tool)
@@ -71,7 +75,9 @@ func TestUpdateSameVersion(t *testing.T) {
 
 	pathBin, err := os.MkdirTemp("", "test-dir")
 	require.Nil(t, err)
-	defer os.RemoveAll(pathBin)
+	defer func() {
+		require.NoError(t, os.RemoveAll(pathBin))
+	}()
 
 	// install the tool
 	err = Install(pathBin, tool)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -38,7 +38,12 @@ func FetchToolList() ([]types.Tool, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			// Just log warning as we're already returning from function
+			fmt.Printf("Error closing response body: %s\n", err)
+		}
+	}()
 
 	if resp.StatusCode == http.StatusOK {
 		body, err := io.ReadAll(resp.Body)
@@ -62,7 +67,12 @@ func fetchTool(toolName string) (types.Tool, error) {
 	if err != nil {
 		return tool, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			// Just log warning as we're already returning from function
+			fmt.Printf("Error closing response body: %s\n", err)
+		}
+	}()
 
 	if resp.StatusCode == http.StatusOK {
 		body, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
because CI. @dogancanbakir 


Fixes errcheck errors by "properly" handling return values of Close() calls

- Fix staticcheck issues by replacing WriteString(fmt.Sprintf()) with fmt.Fprintf()
- Improve error handling in tests