### PR TITLE
build: bump purego to build against newer go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.24.2-alpine AS builder
+FROM golang:1.24.3-alpine AS builder
 RUN apk add --no-cache git
 RUN go install -v github.com/projectdiscovery/pdtm/cmd/pdtm@latest
 
-FROM alpine:3.18.2
+FROM alpine:3.21
 RUN apk -U upgrade --no-cache \
     && apk add --no-cache bind-tools ca-certificates
 COPY --from=builder /go/bin/pdtm /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 ## Installation
 
 
-**`pdtm`** requires **go1.24.2** to install successfully. Run the following command to install the latest version:
+**`pdtm`** requires **go1.24.3** to install successfully. Run the following command to install the latest version:
 
 1. Install using go install -
 
@@ -43,7 +43,7 @@ go install -v github.com/projectdiscovery/pdtm/cmd/pdtm@latest
 
 <table>
 <tr>
-<td>  
+<td>
 
 > **Notes**:
 
@@ -52,9 +52,9 @@ go install -v github.com/projectdiscovery/pdtm/cmd/pdtm@latest
 
 </table>
 </tr>
-</td> 
+</td>
 
-## Usage: 
+## Usage:
 
 
 ```console
@@ -97,11 +97,11 @@ DEBUG:
 
 ```console
 $ pdtm -install-all
-                ____          
-     ____  ____/ / /_____ ___ 
+                ____
+     ____  ____/ / /_____ ___
     / __ \/ __  / __/ __ __  \
    / /_/ / /_/ / /_/ / / / / /
-  / .___/\__,_/\__/_/ /_/ /_/ 
+  / .___/\__,_/\__/_/ /_/ /_/
  /_/                          v0.0.1
 
       projectdiscovery.io
@@ -110,7 +110,7 @@ $ pdtm -install-all
 [INF] Installed nuclei v2.6.3
 [INF] Installed naabu v2.6.3
 [INF] Installed dnsx v2.6.3
-``` 
+```
 
 ### Todo
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/projectdiscovery/pdtm
 
-go 1.24.0
-
-toolchain go1.24.2
+go 1.24.3
 
 require (
 	github.com/charmbracelet/glamour v0.10.0
@@ -35,7 +33,7 @@ require (
 	github.com/cheggaaa/pb/v3 v3.1.7 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
-	github.com/ebitengine/purego v0.8.2 // indirect
+	github.com/ebitengine/purego v0.8.4 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/google/go-github/v30 v30.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707/go.mod h1:qssHWj6
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/ebitengine/purego v0.8.2 h1:jPPGWs2sZ1UgOSgD2bClL0MJIqu58nOmIcBuXr62z1I=
 github.com/ebitengine/purego v0.8.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/ebitengine/purego v0.8.4 h1:CF7LEKg5FFOsASUj0+QwaXf8Ht6TlFxg09+S9wz0omw=
+github.com/ebitengine/purego v0.8.4/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=


### PR DESCRIPTION
[While packaging pdtm](https://github.com/Homebrew/homebrew-core/pull/224635), seeing some purego build issue as below:

```
  link: duplicated definition of symbol dlopen, from github.com/ebitengine/purego and github.com/ebitengine/purego
```

relates to:

- https://github.com/ebitengine/purego/issues/313

closes https://github.com/projectdiscovery/pdtm/issues/411