### PR TITLE
fix version checking

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,12 +11,13 @@ import (
 	"github.com/projectdiscovery/pdtm/pkg/types"
 )
 
-var RegexVersionNumber = regexp.MustCompile(`(?m)[v\s](\d+\.\d+\.\d+)`)
+var (
+	RegexVersionNumber = regexp.MustCompile(`(?m)[v\s](\d+\.\d+\.\d+)`)
+	versionCommands    = []string{"--version", "version"}
+)
 
 func ExtractInstalledVersion(tool types.Tool, basePath string) (string, error) {
 	toolPath := filepath.Join(basePath, tool.Name)
-
-	versionCommands := []string{"--version", "version"}
 
 	for _, versionCmd := range versionCommands {
 		if version, err := tryVersionCommand(toolPath, versionCmd); err == nil {


### PR DESCRIPTION
closes https://github.com/projectdiscovery/pdtm/issues/422

```console
$ go run .

                ____          
     ____  ____/ / /_____ ___ 
    / __ \/ __  / __/ __ __  \
   / /_/ / /_/ / /_/ / / / / /
  / .___/\__,_/\__/_/ /_/ /_/ 
 /_/                         

                projectdiscovery.io

[INF] Current pdtm version v0.1.3 (latest)
[INF] [OS: DARWIN] [ARCH: ARM64] [GO: 1.24.3]
[INF] Path to download project binary: /Users/dogancanbakir/.pdtm/go/bin
[INF] Path /Users/dogancanbakir/.pdtm/go/bin configured in environment variable $PATH
1. aix (latest) (0.0.5)
2. alterx (latest) (0.0.6)
3. asnmap (latest) (1.1.1)
4. cdncheck (outdated) (1.2.2) ➡ (1.2.4)
5. chaos-client (latest) (0.5.2)
6. cloudlist (latest) (1.2.2)
7. dnsx (latest) (1.2.2)
8. httpx (not installed)
9. interactsh-client (not installed)
10. interactsh-server (not installed)
11. katana (latest) (1.2.2)
12. mapcidr (latest) (1.1.96)
13. naabu (latest) (2.3.5)
14. notify (not installed)
15. nuclei (latest) (3.4.10)
16. pdtm (not installed)
17. proxify (latest) (0.0.16)
18. shuffledns (latest) (1.1.0)
19. simplehttpserver (latest) (0.0.6)
20. subfinder (latest) (2.9.0)
21. tldfinder (latest) (0.0.2)
22. tlsx (latest) (1.2.1)
23. tunnelx (not installed)
24. uncover (not installed)
25. urlfinder (latest) (0.0.3)
26. vulnx (latest) (1.0.0)
```