### PR TITLE
docs: add troubleshooting steps for naabu (libpcap-dev required)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,41 @@ DEBUG:
    -v, -verbose             show verbose output
    -nc, -no-color           disable output content coloring (ANSI escape codes)
    -disable-changelog, -dc  disable release changelog in output
+
+
+### Troubleshooting: `naabu` build fails with `pcap.h: No such file or directory`
+
+When `pdtm` installs **naabu** via `go install` (source build), libpcap development headers are required.
+
+**Fix by distro:**
+- **Debian/Ubuntu/Kali**
+  ```bash
+  sudo apt update
+  sudo apt install -y libpcap-dev build-essential
+
+
+**Fix by distro:**
+- **Debian/Ubuntu/Kali**
+  ```bash
+  sudo apt update
+  sudo apt install -y libpcap-dev build-essential
+
+Fedora/RHEL
+
+sudo dnf install -y libpcap-devel @development-tools
+
+Arch
+
+sudo pacman -S --needed libpcap base-devel
+
+Optional: run naabu without sudo
+
+sudo setcap cap_net_raw,cap_net_admin=eip "$(which naabu)"
+
+
+
+
+
 ```
 
 ## Running pdtm

--- a/README.md
+++ b/README.md
@@ -92,38 +92,30 @@ DEBUG:
    -nc, -no-color           disable output content coloring (ANSI escape codes)
    -disable-changelog, -dc  disable release changelog in output
 
-
-### Troubleshooting: `naabu` build fails with `pcap.h: No such file or directory`
-
-When `pdtm` installs **naabu** via `go install` (source build), libpcap development headers are required.
-
-**Fix by distro:**
-- **Debian/Ubuntu/Kali**
-  ```bash
-  sudo apt update
-  sudo apt install -y libpcap-dev build-essential
-
-
-**Fix by distro:**
-- **Debian/Ubuntu/Kali**
-  ```bash
-  sudo apt update
-  sudo apt install -y libpcap-dev build-essential
-
-Fedora/RHEL
-
+#### Troubleshooting `naabu` source builds (pcap.h error)
+ When `pdtm` installs **naabu** via `go install` (source build), **libpcap
+development headers** are required. 
+If they’re missing, the build will fail with:
+ ```bash
+fatal error: pcap.h: No such file or directory
+```
+ **Install prerequisites by distro:**
+ - **Debian / Ubuntu / Kali**
+```bash
+sudo apt update
+sudo apt install -y libpcap-dev build-essential
+```
+ - **Fedora / RHEL**
+```bash
 sudo dnf install -y libpcap-devel @development-tools
-
-Arch
-
+```
+ - **Arch Linux**
+```bash
 sudo pacman -S --needed libpcap base-devel
-
-Optional: run naabu without sudo
-
+```
+ **Optional:** Allow `naabu` to run without sudo 
+```bash
 sudo setcap cap_net_raw,cap_net_admin=eip "$(which naabu)"
-
-
-
 
 
 ```


### PR DESCRIPTION
Adds a Troubleshooting section explaining how to fix the naabu build error
"pcap.h: No such file or directory" when pdtm builds from source.

Includes install commands for Debian/Ubuntu/Kali, Fedora, and Arch.
Tested on Kali (Go 1.24.9, pdtm v0.1.3); installing libpcap-dev fixes the build.
