### PR TITLE
Add missing -silent flag definition

### DIFF
--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -91,6 +91,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVarP(&options.ShowPath, "show-path", "sp", false, "show the current binary path then exit"),
 		flagSet.BoolVar(&options.Version, "version", false, "show version of the project"),
 		flagSet.BoolVarP(&options.Verbose, "verbose", "v", false, "show verbose output"),
+		flagSet.BoolVar(&options.Silent, "silent", false, "silence output"),
 		flagSet.BoolVarP(&options.NoColor, "no-color", "nc", false, "disable output content coloring (ANSI escape codes)"),
 		flagSet.BoolVarP(&options.DisableChangeLog, "dc", "disable-changelog", false, "disable release changelog in output"),
 	)
@@ -104,7 +105,9 @@ func ParseOptions() *Options {
 
 	options.configureOutput()
 
-	showBanner()
+	if !options.Silent {
+		showBanner()
+	}
 
 	if options.Version {
 		gologger.Info().Msgf("Current Version: %s\n", version)


### PR DESCRIPTION
The Silent option was already implemented but the flag definition was missing from the CLI parser.

https://github.com/projectdiscovery/pdtm/blob/e85fa8412ca096c9cfb9a8d6e17b239e2b1360a1/internal/runner/options.go#L148-L150

I also silenced the banner. 

Relates to #436