### PR TITLE
fix changelog version mismatch

### DIFF
--- a/pkg/update.go
+++ b/pkg/update.go
@@ -1,6 +1,7 @@
 package pkg
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -9,7 +10,6 @@ import (
 	ospath "github.com/projectdiscovery/pdtm/pkg/path"
 	"github.com/projectdiscovery/pdtm/pkg/types"
 	"github.com/projectdiscovery/pdtm/pkg/version"
-	updateutils "github.com/projectdiscovery/utils/update"
 
 	"github.com/projectdiscovery/gologger"
 )
@@ -35,7 +35,7 @@ func Update(path string, tool types.Tool, disableChangeLog bool) error {
 			return err
 		}
 		if !disableChangeLog {
-			showReleaseNotes(tool.Repo)
+			showReleaseNotes(tool.Repo, version)
 		}
 		gologger.Info().Msgf("updated %s to %s (%s)", tool.Name, version, au.BrightGreen("latest").String())
 		return nil
@@ -49,22 +49,33 @@ func isUpToDate(tool types.Tool, path string) bool {
 	return err == nil && strings.EqualFold(tool.Version, v)
 }
 
-func showReleaseNotes(toolname string) {
-	gh, err := updateutils.NewghReleaseDownloader(toolname)
+// showReleaseNotes prints the release body for the version that was actually
+// installed. Fetching by tag (instead of "latest") avoids showing notes from
+// a release the user did not get, e.g. when api.pdtm.sh returns a cached
+// older version. See https://github.com/projectdiscovery/pdtm/issues/435.
+func showReleaseNotes(repo, installedVersion string) {
+	body, err := fetchReleaseBody(repo, installedVersion)
 	if err != nil {
-		gologger.Fatal().Label("updater").Msgf("failed to download latest release got %v", err)
+		gologger.Warning().Label("updater").Msgf("could not fetch %s %s release notes: %v", repo, installedVersion, err)
+		return
 	}
-	gh.SetToolName(toolname)
-	output := gh.Latest.GetBody()
-	// adjust colors for both dark / light terminal themes
 	r, err := glamour.NewTermRenderer(glamour.WithAutoStyle())
 	if err != nil {
 		gologger.Error().Msgf("markdown rendering not supported: %v", err)
 	}
-	if rendered, err := r.Render(output); err == nil {
-		output = rendered
+	if rendered, err := r.Render(body); err == nil {
+		body = rendered
 	} else {
 		gologger.Error().Msg(err.Error())
 	}
-	gologger.Print().Msgf("%v\n", output)
+	gologger.Print().Msgf("%v\n", body)
+}
+
+func fetchReleaseBody(repo, installedVersion string) (string, error) {
+	tag := "v" + strings.TrimPrefix(installedVersion, "v")
+	rel, _, err := GithubClient().Repositories.GetReleaseByTag(context.Background(), types.Organization, repo, tag)
+	if err != nil {
+		return "", err
+	}
+	return rel.GetBody(), nil
 }

--- a/pkg/update_test.go
+++ b/pkg/update_test.go
@@ -1,0 +1,16 @@
+package pkg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fetchReleaseBody must return the body of the release tagged with the
+// supplied version, not whatever GitHub currently considers "latest".
+// Regression coverage for https://github.com/projectdiscovery/pdtm/issues/435.
+func TestFetchReleaseBody_PinsToVersion(t *testing.T) {
+	body, err := fetchReleaseBody("dnsx", "1.1.1")
+	require.NoError(t, err)
+	require.NotEmpty(t, body, "release body for dnsx v1.1.1 should be non-empty")
+}


### PR DESCRIPTION
Closes #435.

Pin the post-update changelog to the version actually installed (`GetReleaseByTag`) instead of whatever GitHub currently considers latest. Also demote the changelog-fetch error from `Fatal` to `Warning` so a cosmetic failure does not abort an otherwise successful update.