### PR TITLE
Fix version check

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -122,7 +122,7 @@ func InstalledVersion(tool types.Tool, basePath string, au *aurora.Aurora) strin
 		if !osAvailable {
 			msg = fmt.Sprintf("(%s)", au.Gray(10, "not supported").String())
 		} else {
-			msg = fmt.Sprintf("(%s)", au.BrightYellow("not installed").String())
+			msg = fmt.Sprintf("(%s)", au.BrightYellow(err).String())
 		}
 	}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/logrusorgru/aurora/v4"
+	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/pdtm/pkg/path"
 	"github.com/projectdiscovery/pdtm/pkg/types"
 	"github.com/projectdiscovery/pdtm/pkg/version"
@@ -118,11 +120,16 @@ func InstalledVersion(tool types.Tool, basePath string, au *aurora.Aurora) strin
 
 	installedVersion, err := version.ExtractInstalledVersion(tool, basePath)
 	if err != nil {
-		osAvailable := isOsAvailable(tool)
-		if !osAvailable {
+		switch {
+		case !isOsAvailable(tool):
 			msg = fmt.Sprintf("(%s)", au.Gray(10, "not supported").String())
-		} else {
-			msg = fmt.Sprintf("(%s)", au.BrightYellow(err).String())
+		case errors.Is(err, version.ErrNotInstalled):
+			msg = fmt.Sprintf("(%s)", au.BrightYellow("not installed").String())
+		default:
+			// Keep the listing readable: only surface a generic label and log
+			// the detailed reason (unsupported flag, unparseable output, ...).
+			gologger.Debug().Msgf("could not determine %s version: %s", tool.Name, err)
+			msg = fmt.Sprintf("(%s)", au.BrightYellow("unknown").String())
 		}
 	}
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -19,10 +19,11 @@ var (
 
 func ExtractInstalledVersion(tool types.Tool, basePath string) (string, error) {
 	toolPath := filepath.Join(basePath, tool.Name)
+
 	version, err := tryVersionCommand(toolPath, versionCmd)
 	if err != nil {
 		return "", err
-	} 
+	}
 	return version, nil
 }
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -52,7 +52,10 @@ func tryVersionCommand(toolPath, versionCmd string) (string, error) {
 	cmd.Stderr = &outb
 
 	if err := cmd.Run(); err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
+		// A missing binary surfaces as fs.ErrNotExist on unix and as
+		// exec.ErrNotFound on windows (the .exe is not found on PATH), so both
+		// must be treated as "not installed".
+		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, exec.ErrNotFound) {
 			return "", ErrNotInstalled
 		}
 		return "", fmt.Errorf("%w: %q failed: %v", ErrVersionUnknown, versionCmd, err)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -3,6 +3,7 @@ package version
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os/exec"
 	"path/filepath"
@@ -15,19 +16,29 @@ import (
 var (
 	RegexVersionNumber = regexp.MustCompile(`(?m)[v\s](\d+\.\d+\.\d+)`)
 	versionCommands    = []string{"--version", "version"}
+
+	// ErrNotInstalled is returned when the tool binary is missing.
+	ErrNotInstalled = errors.New("not installed")
+	// ErrVersionUnknown is returned when the binary exists but its version
+	// could not be determined (unsupported flag, empty/unparseable output, ...).
+	// Callers should surface a generic label and may log the wrapped detail.
+	ErrVersionUnknown = errors.New("unknown")
 )
 
 func ExtractInstalledVersion(tool types.Tool, basePath string) (string, error) {
 	toolPath := filepath.Join(basePath, tool.Name)
 
 	var lastErr error
-
 	for _, versionCmd := range versionCommands {
-		version, err := tryVersionCommand(toolPath, versionCmd)
+		ver, err := tryVersionCommand(toolPath, versionCmd)
 		if err == nil {
-			return version, nil
+			return ver, nil
 		}
-
+		// A missing binary won't be resolved by trying another command, and
+		// bailing keeps the surfaced error independent of command ordering.
+		if errors.Is(err, ErrNotInstalled) {
+			return "", err
+		}
 		lastErr = err
 	}
 
@@ -42,23 +53,23 @@ func tryVersionCommand(toolPath, versionCmd string) (string, error) {
 
 	if err := cmd.Run(); err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return "", errors.New("not installed")
+			return "", ErrNotInstalled
 		}
-		return "", errors.New("unknown")
+		return "", fmt.Errorf("%w: %q failed: %v", ErrVersionUnknown, versionCmd, err)
 	}
 
 	output := outb.String()
 	if output == "" {
-		return "", errors.New("empty output")
+		return "", fmt.Errorf("%w: %q produced no output", ErrVersionUnknown, versionCmd)
 	}
 
 	installedVersion := RegexVersionNumber.FindString(strings.ToLower(output))
 	if installedVersion == "" {
-		return "", errors.New("no version found in output")
+		return "", fmt.Errorf("%w: no version found in %q output", ErrVersionUnknown, versionCmd)
 	}
 
-	version := strings.TrimSpace(installedVersion)
-	version = strings.TrimPrefix(version, "v")
+	ver := strings.TrimSpace(installedVersion)
+	ver = strings.TrimPrefix(ver, "v")
 
-	return version, nil
+	return ver, nil
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -3,6 +3,7 @@ package version
 import (
 	"bytes"
 	"errors"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -13,19 +14,17 @@ import (
 
 var (
 	RegexVersionNumber = regexp.MustCompile(`(?m)[v\s](\d+\.\d+\.\d+)`)
-	versionCommands    = []string{"--version", "version"}
+	versionCmd         = "--version"
 )
 
 func ExtractInstalledVersion(tool types.Tool, basePath string) (string, error) {
 	toolPath := filepath.Join(basePath, tool.Name)
 
-	for _, versionCmd := range versionCommands {
-		if version, err := tryVersionCommand(toolPath, versionCmd); err == nil {
-			return version, nil
-		}
+	if version, err := tryVersionCommand(toolPath, versionCmd); err == nil {
+		return version, nil
+	} else {
+		return "", err
 	}
-
-	return "", errors.New("unable to extract installed version")
 }
 
 func tryVersionCommand(toolPath, versionCmd string) (string, error) {
@@ -35,7 +34,10 @@ func tryVersionCommand(toolPath, versionCmd string) (string, error) {
 	cmd.Stderr = &outb
 
 	if err := cmd.Run(); err != nil {
-		return "", err
+		if os.IsNotExist(err) {
+		return "", errors.New("not installed")
+		}
+	return "", err
 	}
 
 	output := outb.String()

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -19,12 +19,11 @@ var (
 
 func ExtractInstalledVersion(tool types.Tool, basePath string) (string, error) {
 	toolPath := filepath.Join(basePath, tool.Name)
-
-	if version, err := tryVersionCommand(toolPath, versionCmd); err == nil {
-		return version, nil
-	} else {
+	version, err := tryVersionCommand(toolPath, versionCmd)
+	if err != nil {
 		return "", err
-	}
+	} 
+	return version, nil
 }
 
 func tryVersionCommand(toolPath, versionCmd string) (string, error) {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -3,7 +3,7 @@ package version
 import (
 	"bytes"
 	"errors"
-	"os"
+	"io/fs"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -34,10 +34,10 @@ func tryVersionCommand(toolPath, versionCmd string) (string, error) {
 	cmd.Stderr = &outb
 
 	if err := cmd.Run(); err != nil {
-		if os.IsNotExist(err) {
-		return "", errors.New("not installed")
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", errors.New("not installed")
 		}
-	return "", err
+		return "", err
 	}
 
 	output := outb.String()

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -37,7 +37,7 @@ func tryVersionCommand(toolPath, versionCmd string) (string, error) {
 		if errors.Is(err, fs.ErrNotExist) {
 			return "", errors.New("not installed")
 		}
-		return "", err
+		return "", errors.New("unknown")
 	}
 
 	output := outb.String()

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,17 +14,24 @@ import (
 
 var (
 	RegexVersionNumber = regexp.MustCompile(`(?m)[v\s](\d+\.\d+\.\d+)`)
-	versionCmd         = "--version"
+	versionCommands    = []string{"--version", "version"}
 )
 
 func ExtractInstalledVersion(tool types.Tool, basePath string) (string, error) {
 	toolPath := filepath.Join(basePath, tool.Name)
 
-	version, err := tryVersionCommand(toolPath, versionCmd)
-	if err != nil {
-		return "", err
+	var lastErr error
+
+	for _, versionCmd := range versionCommands {
+		version, err := tryVersionCommand(toolPath, versionCmd)
+		if err == nil {
+			return version, nil
+		}
+
+		lastErr = err
 	}
-	return version, nil
+
+	return "", lastErr
 }
 
 func tryVersionCommand(toolPath, versionCmd string) (string, error) {

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,83 @@
+package version
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/projectdiscovery/pdtm/pkg/types"
+)
+
+// writeFakeTool drops an executable script at basePath/name that prints script
+// to stdout and exits with code. Returns the base dir.
+func writeFakeTool(t *testing.T, name, script string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-tool shell scripts are not executable on windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+script+"\n"), 0o755); err != nil {
+		t.Fatalf("write fake tool: %v", err)
+	}
+	return dir
+}
+
+func TestExtractInstalledVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		script  string
+		want    string
+		wantErr error
+	}{
+		{
+			name:   "supports --version",
+			script: `[ "$1" = "--version" ] && echo "mytool v1.2.3" || exit 1`,
+			want:   "1.2.3",
+		},
+		{
+			name:   "only supports version subcommand",
+			script: `[ "$1" = "version" ] && echo "Current version 2.0.1" || exit 2`,
+			want:   "2.0.1",
+		},
+		{
+			name:    "installed but no version in output",
+			script:  `echo "usage: mytool [flags]"`,
+			wantErr: ErrVersionUnknown,
+		},
+		{
+			name:    "installed but empty output and non-zero exit",
+			script:  `exit 3`,
+			wantErr: ErrVersionUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := writeFakeTool(t, "mytool", tt.script)
+			got, err := ExtractInstalledVersion(types.Tool{Name: "mytool"}, dir)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("err = %v, want wrap of %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("version = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractInstalledVersionNotInstalled(t *testing.T) {
+	dir := t.TempDir() // empty: binary does not exist
+	_, err := ExtractInstalledVersion(types.Tool{Name: "missing-tool"}, dir)
+	if !errors.Is(err, ErrNotInstalled) {
+		t.Fatalf("err = %v, want wrap of ErrNotInstalled", err)
+	}
+}


### PR DESCRIPTION
There was a logical bug in  pkg/version/version.go that did an early return from a function that extracted installed versions; only the --version flag was checked. My changes propose to completely remove the second flag (version) to keep consistency across all PD tools. Also fixed the error message that was hard-coded and confusing.
<details>
  <summary>Before</summary>
  
  ```bash
  ❯ pdtm
  skip
23. tunnelx (not installed)
24. uncover (latest) (1.2.1)
25. urlfinder (not installed)
26. vulnx (not installed)
❯ vulnx version
[INF] Current vulnx version 2.0.1 (latest)
❯ tunnelx --help
A socks5 proxy server that tunnels traffic through a remote server
❯ urlfinder
fish: Unknown command: urlfinder
```
</details>
<details>
  <summary>After</summary>
  
  ```bash
  ❯ ./pdtm
  skip
23. tunnelx (exit status 2)
24. uncover (latest) (1.2.1)
25. urlfinder (not installed)
26. vulnx (exit status 1)
```
</details>
vulnx and tunnelx will throw an error even when installed because they do not currently use the --version flag. It is already fixed in the latest git commit of tunnelx but not in the build release. Below is latest tunnelx builded myself and placed into .pdtm/go/bin

```bash
snip
23. tunnelx (latest) (0.0.1)
```
This shouldn't happen in the future as all new applications should be advised to implement --version flag.
Kinda reverts #423